### PR TITLE
feat: 상품 목록 카드 컴포넌트 통합

### DIFF
--- a/src/components/product/basket-card-list/index.tsx
+++ b/src/components/product/basket-card-list/index.tsx
@@ -18,7 +18,7 @@ const BasketCardList = () => {
   return (
     <div className={styles.basketCardList}>
       {baskets.map(basket => (
-        <BasketCard key={basket.id} {...basket} />
+        <BasketCard key={basket.id} {...basket} tab="home" />
       ))}
       {hasNextPage && <div ref={observeRef} />}
     </div>

--- a/src/components/product/basket-card/index.tsx
+++ b/src/components/product/basket-card/index.tsx
@@ -17,6 +17,7 @@ const BasketCard = ({
   secondOption,
   thirdOption,
   waitingCount,
+  tab,
 }: BasketProps) => {
   const { mutate: copyBasketsMutate } = useCopyBaskets();
 
@@ -42,13 +43,17 @@ const BasketCard = ({
         <BasketBadge>{category}</BasketBadge>
         <p className={styles.name}>{name}</p>
         <p className={styles.options}>{description}</p>
-        <p className={styles.waitingCount}>
-          <Image src="/icons/user.png" width={12} height={12} alt="user" /> 함께 기다리는 사람{' '}
-          {waitingCount} 명
-        </p>
-        <button onClick={handleWaitTogetherButtonClick} className={styles.waitTogetherButton}>
-          함께 기다리기
-        </button>
+        {tab === 'home' && (
+          <div>
+            <p className={styles.waitingCount}>
+              <Image src="/icons/user.png" width={12} height={12} alt="user" /> 함께 기다리는 사람{' '}
+              {waitingCount} 명
+            </p>
+            <button onClick={handleWaitTogetherButtonClick} className={styles.waitTogetherButton}>
+              함께 기다리기
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/product/my-basket-card-list/index.css.ts
+++ b/src/components/product/my-basket-card-list/index.css.ts
@@ -1,8 +1,13 @@
 import { style } from '@vanilla-extract/css';
 
 export const myBasketCardList = style({
-  display: 'flex',
-  flexWrap: 'wrap',
-  columnGap: '18px',
-  rowGap: '40px',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  columnGap: '1vw',
+  rowGap: '5vh',
+  '@media': {
+    'screen and (max-width: 768px)': {
+      gridTemplateColumns: 'repeat(2, 1fr)',
+    },
+  },
 });

--- a/src/components/product/my-basket-card-list/index.tsx
+++ b/src/components/product/my-basket-card-list/index.tsx
@@ -1,6 +1,6 @@
 import { useGetMyBaskets } from '@/hooks/quries/use-get-my-baskets';
 
-import MyBasketCard from '../my-basket-card';
+import BasketCard from '../basket-card';
 import * as styles from './index.css';
 
 const MyBasketCardList = () => {
@@ -9,7 +9,7 @@ const MyBasketCardList = () => {
   return (
     <div className={styles.myBasketCardList}>
       {myBaskets.map(myBasket => (
-        <MyBasketCard key={myBasket.id} {...myBasket} />
+        <BasketCard key={myBasket.id} {...myBasket} tab="my-basket" />
       ))}
     </div>
   );

--- a/src/types/basket.ts
+++ b/src/types/basket.ts
@@ -10,7 +10,9 @@ export interface Basket {
   firstOption: string;
   secondOption?: string;
   thirdOption?: string;
-  waitingCount: number;
+  waitingCount?: number;
+  tab: 'home' | 'my-basket';
+  // isHidden: boolean;
 }
 
 export interface MyBasket {


### PR DESCRIPTION
## 작업 내용

- 나의 알림 탭에서도 홈 탭 상품 목록과 동일한 UI로 보이도록 수정했어요.
- 추후 유지보수성을 고려해 BasketCard 컴포넌트를 하나로 통합했어요.
   - tab 속성에 따라 '함께 기다리기' 영역 조건부 렌더링 


