### PR TITLE
feat: 헤더 마이페이지 버튼 로그인 전/후 상태에 따른 분기처리 적용

### DIFF
--- a/src/components/common/header/index.css.ts
+++ b/src/components/common/header/index.css.ts
@@ -1,3 +1,4 @@
+import { tokens } from '@/styles';
 import { style } from '@vanilla-extract/css';
 
 export const header = style({
@@ -19,4 +20,16 @@ export const rightHeaderWrapper = style({
   display: 'flex',
   alignItems: 'center',
   gap: '12px',
+});
+
+export const loginBtn = style({
+  all: 'unset',
+  width: '13rem',
+  height: '3.3rem',
+  backgroundColor: tokens.colors.surface,
+  borderRadius: '0.4rem',
+  fontSize: '1.4rem',
+  fontWeight: 700,
+  textAlign: 'center',
+  cursor: 'pointer',
 });

--- a/src/components/common/header/index.tsx
+++ b/src/components/common/header/index.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import Icon from '@/components/icons';
+import { useLogin } from '@/hooks/common/use-login';
 import { LOCAL_STORAGE_KEY, Storage } from '@/libs/storage';
 import { useLoginModalStore } from '@/store/use-login-modal-store';
 
@@ -12,17 +13,15 @@ const Header = () => {
   const pathname = usePathname();
   const router = useRouter();
   const openLoginModal = useLoginModalStore(state => state.openLoginModal);
+  const { kakaoLogin } = useLogin();
 
   const handleLogoClick = () => {
     router.push('/');
   };
 
-  // const { data: myInfo } = useGetMyInfo({
-  //   // interceptorResponseRejected에서 401에러 발생하면 /login으로 이동하도록 설정되어있고,
-  //   // /login으로 이동하면 useGetMyInfo api가 또 호출하면서 401을 뱉어서 무한루프에 빠지는 문제가 있습니다.
-  //   // 그래서 아래와 같이 enabled를 설정해주었습니다.
-  //   enabled: pathname !== '/login' && Boolean(Storage.getItem('access-token')),
-  // });
+  const handleLoginBtn = () => {
+    kakaoLogin();
+  };
 
   const accessToken = Storage.getItem(LOCAL_STORAGE_KEY.accessToken);
 
@@ -47,15 +46,20 @@ const Header = () => {
         </button> */}
 
         <Icon icon="Bell" width={24} height={24} />
-
-        <Icon
-          icon="Avatar"
-          width={36}
-          height={36}
-          cursor="pointer"
-          onClick={() => (accessToken ? router.push('/mypage') : openLoginModal())}
-          // onClick={() => router.push(accessToken ? '/mypage' : `/login?redirect=/mypage`)}
-        />
+        {accessToken ? (
+          <Icon
+            icon="Avatar"
+            width={36}
+            height={36}
+            cursor="pointer"
+            onClick={() => (accessToken ? router.push('/mypage') : openLoginModal())}
+            // onClick={() => router.push(accessToken ? '/mypage' : `/login?redirect=/mypage`)}
+          />
+        ) : (
+          <button className={styles.loginBtn} onClick={handleLoginBtn}>
+            카카오로 로그인하기
+          </button>
+        )}
       </div>
     </header>
   );

--- a/src/hooks/common/use-login.ts
+++ b/src/hooks/common/use-login.ts
@@ -1,0 +1,11 @@
+import { useRouter } from 'next/navigation';
+
+export const useLogin = () => {
+  const router = useRouter();
+
+  const kakaoLogin = () => {
+    router.push(`https://alilm.store/oauth2/authorization/kakao`);
+  };
+
+  return { kakaoLogin };
+};


### PR DESCRIPTION
- useLogin 훅 생성

## 작업 내용

- 로그인 전 상태에서 '카카오로 로그인하기' 버튼 표시되도록 구현했습니다.
- 버튼 클릭 즉시 카카오 로그인이 진행됩니다.
- 카카오 로그인 경로로 보내주는 코드를 재사용할 수 있도록 hook으로 만들었습니다.

## 스크린샷

![image](https://github.com/user-attachments/assets/c6f20c4e-bd98-4e72-b9ae-923c5843dcf8)