### PR TITLE
feat: 상품 전체 조회, 알림 수 조회 Endpoint 수정 및 재입고 등록 시 상품 이미지 여러 장 보내도록 수정

### DIFF
--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -37,6 +37,7 @@ export async function POST(request: NextRequest) {
     }
 
     const productData = JSON.parse(jsonData);
+    console.log(productData);
 
     if (!productData.goodsNo) {
       return NextResponse.json({ error: ERROR_CODE.PRODUCT_NOT_FOUND }, { status: 404 });
@@ -44,13 +45,16 @@ export async function POST(request: NextRequest) {
 
     const options = extractOptions(soldoutCheckResponse);
 
+    const productImageUrl = productData.goodsImages?.map(
+      (image: { imageUrl: string[] }) => `https://image.msscdn.net${image.imageUrl}`
+    );
+
     const result = {
       number: productData.goodsNo,
       name: productData.goodsNm,
       brand: productData.brand,
-      imageUrl: productData.thumbnailImageUrl
-        ? `https://image.msscdn.net${productData.thumbnailImageUrl}`
-        : null,
+      thumbnailUrl: `https://image.msscdn.net${productData.thumbnailImageUrl}`,
+      imageUrlList: productImageUrl ? productImageUrl : [],
       category: productData.category?.categoryDepth1Title,
       price: productData.goodsPrice?.maxPrice,
       store: 'MUSINSA',

--- a/src/components/create/product-options-form/index.tsx
+++ b/src/components/create/product-options-form/index.tsx
@@ -36,7 +36,7 @@ const ProductOptionsForm = ({ product, isPending, setCreateForm }: ProductOption
   return (
     <>
       <Image
-        src={product.imageUrl}
+        src={product.thumbnailUrl}
         alt="Product Preview"
         className={styles.previewImage}
         width={800}

--- a/src/components/product/basket-card-list/index.tsx
+++ b/src/components/product/basket-card-list/index.tsx
@@ -1,19 +1,19 @@
 import { useIntersection } from '@/hooks/common/use-intersection';
-import { useGetBaskets } from '@/hooks/queries/use-get-baskets';
+import { useGetProducts } from '@/hooks/queries/use-get-baskets';
 
-import BasketCard from '../basket-card';
+import ProductCard from '../basket-card';
 import BasketCardSkeleton from '../basket-card/basket-card-skeleton';
 import * as styles from './index.css';
 
 const BasketCardList = () => {
   const {
-    data: baskets,
+    data: products,
     fetchNextPage,
     hasNextPage,
     isFetching,
     isLoading,
     isFetchingNextPage,
-  } = useGetBaskets();
+  } = useGetProducts();
 
   const observeRef = useIntersection((entry, observer) => {
     observer.unobserve(entry.target);
@@ -25,8 +25,8 @@ const BasketCardList = () => {
 
   return (
     <div className={styles.basketCardList}>
-      {baskets?.map(basket => (
-        <BasketCard key={basket?.id} {...basket} tab="home" isLoading={isLoading} />
+      {products?.map(product => (
+        <ProductCard key={product?.id} {...product} tab="home" isLoading={isLoading} />
       ))}
 
       {isFetchingNextPage &&

--- a/src/components/product/basket-card/index.tsx
+++ b/src/components/product/basket-card/index.tsx
@@ -3,22 +3,23 @@
 import Image from 'next/image';
 import { BasketBadge } from '@/components/product/basket-badge';
 import { useCopyBaskets } from '@/hooks/mutations/use-copy-baskets';
-import { type Basket } from '@/types/basket';
+import { type Product } from '@/types/basket';
 
 import WaitingCounts from '../waiting-counts';
 import BasketCardSkeleton from './basket-card-skeleton';
 import * as styles from './index.css';
 
-type BasketProps = Basket & {
+type BasketProps = Product & {
   isLoading?: boolean;
 };
 
-const BasketCard = ({
+const ProductCard = ({
   id,
   number,
   name,
   brand,
   imageUrl,
+  thumbnailUrl,
   category,
   firstOption,
   secondOption,
@@ -48,7 +49,7 @@ const BasketCard = ({
       <div onClick={handleProductClick} style={{ cursor: 'pointer' }}>
         <div className={styles.imageWrapper}>
           <Image
-            src={imageUrl}
+            src={tab === 'home' ? thumbnailUrl : imageUrl}
             className={styles.thumbnailImage}
             alt="Basket Thumbnail"
             width={800}
@@ -75,4 +76,4 @@ const BasketCard = ({
   );
 };
 
-export default BasketCard;
+export default ProductCard;

--- a/src/components/product/my-basket-card-list/index.tsx
+++ b/src/components/product/my-basket-card-list/index.tsx
@@ -1,6 +1,6 @@
 import { useGetMyBaskets } from '@/hooks/queries/use-get-my-baskets';
 
-import BasketCard from '../basket-card';
+import ProductCard from '../basket-card';
 import MyBasketCard from '../my-basket-card';
 import { cardListHome, cardListMypage } from './index.css';
 
@@ -16,7 +16,7 @@ const MyBasketCardList = ({ type }: MyBasketCardListProps) => {
       {type === 'home' && (
         <div className={cardListHome}>
           {myBaskets?.map(myBasket => (
-            <BasketCard key={myBasket.id} {...myBasket} tab="my-basket" />
+            <ProductCard key={myBasket.id} {...myBasket} tab="my-basket" />
           ))}
         </div>
       )}

--- a/src/hooks/mutations/use-copy-baskets.ts
+++ b/src/hooks/mutations/use-copy-baskets.ts
@@ -2,7 +2,7 @@ import { post } from '@/libs/api/client';
 import { useModalStore } from '@/store/use-modal-store';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { BASKETS_QUERY_KEY } from '../queries/use-get-baskets';
+import { PRODUCTS_QUERY_KEY } from '../queries/use-get-baskets';
 
 const postCopyBaskets = async (productId: number) => {
   await post('/baskets/copy', { productId });
@@ -16,7 +16,7 @@ export const useCopyBaskets = () => {
     mutationFn: async (productId: number) => await postCopyBaskets(productId),
     onSuccess: () => {
       onOpen({ modalType: 'alert', title: '함께 기다리기 성공!' });
-      queryClient.invalidateQueries({ queryKey: [BASKETS_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: [PRODUCTS_QUERY_KEY] });
     },
     onError: error => {
       if (error.message.includes('ALILM-008')) {

--- a/src/hooks/mutations/use-post-url-crawling-product.ts
+++ b/src/hooks/mutations/use-post-url-crawling-product.ts
@@ -7,7 +7,8 @@ export interface UsePostUrlCrawlingProductResponse {
   number: number;
   name: string;
   brand: string;
-  imageUrl: string;
+  thumbnailUrl: string;
+  imageUrlList: string[];
   category: string;
   price: number;
   store: string;

--- a/src/hooks/mutations/use-registered-baskets.ts
+++ b/src/hooks/mutations/use-registered-baskets.ts
@@ -3,14 +3,14 @@ import { post } from '@/libs/api/client';
 import { useModalStore } from '@/store/use-modal-store';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { BASKETS_QUERY_KEY } from '../queries/use-get-baskets';
+import { PRODUCTS_QUERY_KEY } from '../queries/use-get-baskets';
 import { MY_BASKETS_QUERY_KEY } from '../queries/use-get-my-baskets';
 
 export interface RegisteredBasketsParams {
   number: number;
   name: string;
   brand: string;
-  imageUrl: string;
+  imageUrlList: string[];
   category: string;
   price: number;
   store: string;
@@ -32,7 +32,7 @@ export const useRegisteredBaskets = () => {
     mutationFn: async (params: RegisteredBasketsParams) => await postRegisteredBaskets(params),
     onSuccess: () => {
       onOpen({ modalType: 'alert', title: '상품 등록 성공!' });
-      queryClient.invalidateQueries({ queryKey: [BASKETS_QUERY_KEY, MY_BASKETS_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: [PRODUCTS_QUERY_KEY, MY_BASKETS_QUERY_KEY] });
       router.replace('/');
     },
     onError: () => onOpen({ modalType: 'alert', title: '이미 등록된 상품이에요.' }),

--- a/src/hooks/queries/use-get-baskets.ts
+++ b/src/hooks/queries/use-get-baskets.ts
@@ -1,28 +1,30 @@
 import { get } from '@/libs/api/client';
-import { type Basket } from '@/types/basket';
+import { type Product } from '@/types/basket';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-interface BasketsResponse {
-  size: number;
-  contents: Basket[];
-  last: boolean;
-  hasNext: boolean;
+interface ProductsResponse {
+  customSlice: {
+    size: number;
+    contents: Product[];
+    last: boolean;
+    hasNext: boolean;
+  };
 }
 
-export const BASKETS_QUERY_KEY = 'getBaskets';
+export const PRODUCTS_QUERY_KEY = 'getProducts';
 
-export const getBaskets = async (pageParam: number) => {
-  return await get<BasketsResponse>(`/products?size=9&page=${pageParam}`);
+export const getProducts = async (pageParam: number) => {
+  return await get<ProductsResponse>(`/products?size=9&page=${pageParam}`);
 };
 
-export const useGetBaskets = () => {
+export const useGetProducts = () => {
   return useInfiniteQuery({
-    queryKey: [BASKETS_QUERY_KEY],
-    queryFn: async ({ pageParam }) => await getBaskets(pageParam),
+    queryKey: [PRODUCTS_QUERY_KEY],
+    queryFn: async ({ pageParam }) => await getProducts(pageParam),
     getNextPageParam: (lastPage, allPages) => {
-      return lastPage.hasNext ? allPages.length : null;
+      return lastPage.customSlice.hasNext ? allPages.length : null;
     },
-    select: data => data.pages.flatMap(({ contents }) => contents),
+    select: data => data.pages.flatMap(page => page.customSlice.contents),
     initialPageParam: 0,
   });
 };

--- a/src/hooks/queries/use-get-notifications-count.ts
+++ b/src/hooks/queries/use-get-notifications-count.ts
@@ -9,7 +9,7 @@ interface NotificationsCountResponse {
 export const NOTIFICATION_COUNT_QUERY_KEY = 'getNotificationCount';
 
 export const getNotificationsCount = async () => {
-  const data = await get<NotificationsCountResponse>('/notifications/count');
+  const data = await get<NotificationsCountResponse>('/alilms/count');
 
   return data;
 };

--- a/src/libs/api/client.ts
+++ b/src/libs/api/client.ts
@@ -94,11 +94,21 @@ export const setupInterceptors = (openLoginModal: () => void) => {
 export { instance };
 
 export const get = <T>(...args: Parameters<typeof instance.get>) => {
-  return instance.get<T, T>(...args);
-};
+  const [url, config] = args;
 
+  return instance.get<T, T>(url, {
+    ...config,
+    baseURL: url.includes('products') ? 'https://alilm.store/api/v2' : instance.defaults.baseURL,
+  });
+};
 export const post = <T>(...args: Parameters<typeof instance.post>) => {
-  return instance.post<T, T>(...args);
+  const [url, data, config] = args;
+
+  return instance.post<T, T>(url, data, {
+    ...config,
+    baseURL:
+      url === '/baskets/registered' ? 'https://alilm.store/api/v2' : instance.defaults.baseURL,
+  });
 };
 
 export const put = <T>(...args: Parameters<typeof instance.put>) => {

--- a/src/types/basket.ts
+++ b/src/types/basket.ts
@@ -1,8 +1,9 @@
-export interface Basket {
+export interface Product {
   id: number;
   number: number;
   name: string;
   brand: string;
+  thumbnailUrl: string;
   imageUrl: string;
   store: string;
   price: number;
@@ -20,6 +21,7 @@ export interface MyBasket {
   number: number;
   name: string;
   brand: string;
+  thumbnailUrl: string;
   imageUrl: string;
   store: string;
   price: number;


### PR DESCRIPTION
close #105
close #106

## 작업 내용
- 상품 전체, 알림 수 조회, 상품 등록 Endpoint를 수정하고, 변경된 데이터 구조에 따라 일부 코드를 수정했습니다.
- 재입고 상품 등록 시 이미지 여러 장 Post되도록 구현했습니다.

