### PR TITLE
Feat/#111 - 상품 등록 시 하위 카테고리 수집하도록 변경

### DIFF
--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -56,6 +56,7 @@ export async function POST(request: NextRequest) {
       brand: productData.brand,
       thumbnailUrl: `https://image.msscdn.net${productData.thumbnailImageUrl}`,
       imageUrlList: productImageUrl ? productImageUrl : [],
+      category: productData.category?.categoryDepth1Title,
       firstCategory: productData.category?.categoryDepth1Title,
       secondCategory: productData.category?.categoryDepth2Title,
       price: productData.goodsPrice?.maxPrice,

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -56,13 +56,16 @@ export async function POST(request: NextRequest) {
       brand: productData.brand,
       thumbnailUrl: `https://image.msscdn.net${productData.thumbnailImageUrl}`,
       imageUrlList: productImageUrl ? productImageUrl : [],
-      category: productData.category?.categoryDepth1Title,
+      firstCategory: productData.category?.categoryDepth1Title,
+      secondCategory: productData.category?.categoryDepth2Title,
       price: productData.goodsPrice?.maxPrice,
       store: 'MUSINSA',
       firstOptions: options.first,
       secondOptions: options.second,
       thirdOptions: options.third,
     };
+
+    console.log(result);
 
     return NextResponse.json(result);
   } catch (error) {

--- a/src/hooks/mutations/use-post-url-crawling-product.ts
+++ b/src/hooks/mutations/use-post-url-crawling-product.ts
@@ -9,6 +9,7 @@ export interface UsePostUrlCrawlingProductResponse {
   brand: string;
   thumbnailUrl: string;
   imageUrlList: string[];
+  category: string;
   firstCategory: string;
   secondCategory: string;
   price: number;

--- a/src/hooks/mutations/use-post-url-crawling-product.ts
+++ b/src/hooks/mutations/use-post-url-crawling-product.ts
@@ -9,7 +9,8 @@ export interface UsePostUrlCrawlingProductResponse {
   brand: string;
   thumbnailUrl: string;
   imageUrlList: string[];
-  category: string;
+  firstCategory: string;
+  secondCategory: string;
   price: number;
   store: string;
   firstOptions: string[];

--- a/src/hooks/mutations/use-registered-baskets.ts
+++ b/src/hooks/mutations/use-registered-baskets.ts
@@ -11,7 +11,8 @@ export interface RegisteredBasketsParams {
   name: string;
   brand: string;
   imageUrlList: string[];
-  category: string;
+  firstCategory: string;
+  secondCategory: string;
   price: number;
   store: string;
   firstOption: string;
@@ -35,6 +36,8 @@ export const useRegisteredBaskets = () => {
       queryClient.invalidateQueries({ queryKey: [PRODUCTS_QUERY_KEY, MY_BASKETS_QUERY_KEY] });
       router.replace('/');
     },
-    onError: () => onOpen({ modalType: 'alert', title: '이미 등록된 상품이에요.' }),
+    onError: error => {
+      onOpen({ modalType: 'alert', title: error.message });
+    },
   });
 };

--- a/src/hooks/mutations/use-registered-baskets.ts
+++ b/src/hooks/mutations/use-registered-baskets.ts
@@ -11,6 +11,7 @@ export interface RegisteredBasketsParams {
   name: string;
   brand: string;
   imageUrlList: string[];
+  category: string;
   firstCategory: string;
   secondCategory: string;
   price: number;

--- a/src/libs/api/client.ts
+++ b/src/libs/api/client.ts
@@ -61,6 +61,10 @@ export const interceptorResponseRejected = (openLoginModal: () => void) => {
       return Promise.reject(new CustomException(errorMessage.BAD_REQUEST_409, 'ERR_BAD_REQUEST'));
     }
 
+    if (error.status === 400) {
+      return Promise.reject(new CustomException(errorMessage.UNKNOWN_400, 'ERR_BAD_REQUEST'));
+    }
+
     // if (error.response?.data?.['response_messages']) {
     //   return Promise.reject(new ApiException(error.response.data, error.response.status));
     // }


### PR DESCRIPTION
## 작업 내용
- 상품 등록 시 하위 카테고리 수집하도록 변경
  - As is: 기존 category 필드를 통해 상위 카테고리 하나만 수집
  - To be: firstCategory, secondCategory를 추가해 하위 카테고리까지 수집하도록 구현
  (e.g. firstCategory: '스포츠/레저', secondCategory: '아우터')