### PR TITLE
[Feat/#119] 알림 받은 상품 표시 & 삭제 버튼 추가

### DIFF
--- a/src/components/common/toast/index.css.ts
+++ b/src/components/common/toast/index.css.ts
@@ -14,6 +14,8 @@ const fadeOut = keyframes({
 export const toastContainer = style({
   width: '100%',
   height: '4.6rem',
+  display: 'flex',
+  alignItems: 'center',
   padding: '1.6rem 2rem',
   backgroundColor: tokens.colors.toast,
   borderRadius: '0.4rem',

--- a/src/components/product/basket-card-list/index.css.ts
+++ b/src/components/product/basket-card-list/index.css.ts
@@ -6,7 +6,7 @@ export const basketCardList = style({
   columnGap: '1.8rem',
   rowGap: '5vh',
   '@media': {
-    'screen and (max-width: 768px)': {
+    'screen and (max-width: 576px)': {
       gridTemplateColumns: 'repeat(2, 1fr)',
     },
   },

--- a/src/components/product/delete-product/index.css.ts
+++ b/src/components/product/delete-product/index.css.ts
@@ -1,0 +1,16 @@
+import { style } from '@vanilla-extract/css';
+
+export const deleteBtn = style({
+  all: 'unset',
+  width: '7.7rem',
+  height: '3.3rem',
+  fontSize: '1.4rem',
+  fontWeight: '600',
+  textAlign: 'center',
+  marginTop: '0.6rem',
+  color: '#101010',
+  backgroundColor: '#FAFAFA',
+  border: '0.1rem solid #EEEEEE',
+  borderRadius: '0.4rem',
+  cursor: 'pointer',
+});

--- a/src/components/product/delete-product/index.tsx
+++ b/src/components/product/delete-product/index.tsx
@@ -1,0 +1,34 @@
+import { useDeleteBasket } from '@/hooks/mutations/use-delete-basket';
+import { useModalStore } from '@/store/use-modal-store';
+import { type MyBasket } from '@/types/basket';
+
+import * as styles from './index.css';
+
+export interface DeleteProductBtnProps {
+  id: MyBasket['id'];
+  name: MyBasket['name'];
+}
+
+const DeleteProductBtn = ({ id, name }: DeleteProductBtnProps) => {
+  const { mutate: deleteBasket } = useDeleteBasket();
+
+  const onOpen = useModalStore(state => state.onOpen);
+
+  const handleDeleteBtn = () => {
+    onOpen({
+      modalType: 'confirm',
+      title: '상품을 삭제하시겠습니까?',
+      description: name,
+      onClick: () => deleteBasket(id),
+      mainBtnText: '삭제',
+    });
+  };
+
+  return (
+    <button className={styles.deleteBtn} onClick={handleDeleteBtn}>
+      삭제하기
+    </button>
+  );
+};
+
+export default DeleteProductBtn;

--- a/src/components/product/my-basket-card-list/index.css.ts
+++ b/src/components/product/my-basket-card-list/index.css.ts
@@ -1,3 +1,4 @@
+import { tokens } from '@/styles';
 import { style } from '@vanilla-extract/css';
 
 export const cardListHome = style({
@@ -16,4 +17,18 @@ export const cardListMypage = style({
   display: 'grid',
   // gridTemplateColumns: 'repeat(1fr)',
   rowGap: '2.4rem',
+});
+
+export const infoBox = style({
+  width: '100%',
+  height: '4.9rem',
+  borderRadius: '0.8rem',
+  backgroundColor: tokens.colors.background,
+  color: '#717171',
+  padding: '1.6rem',
+  fontSize: '1.4rem',
+  marginBottom: '2.4rem',
+  display: 'flex',
+  gap: '0.8rem',
+  alignItems: 'center',
 });

--- a/src/components/product/my-basket-card-list/index.css.ts
+++ b/src/components/product/my-basket-card-list/index.css.ts
@@ -4,10 +4,10 @@ import { style } from '@vanilla-extract/css';
 export const cardListHome = style({
   display: 'grid',
   gridTemplateColumns: 'repeat(3, 1fr)',
-  columnGap: '1vw',
+  columnGap: '1.8rem',
   rowGap: '5vh',
   '@media': {
-    'screen and (max-width: 768px)': {
+    'screen and (max-width: 576px)': {
       gridTemplateColumns: 'repeat(2, 1fr)',
     },
   },

--- a/src/components/product/my-basket-card-list/index.tsx
+++ b/src/components/product/my-basket-card-list/index.tsx
@@ -1,8 +1,9 @@
 import { useGetMyBaskets } from '@/hooks/queries/use-get-my-baskets';
+import { BellRing } from 'lucide-react';
 
 import MyBasketCard from '../my-basket-card';
 import ProductCard from '../product-card';
-import { cardListHome, cardListMypage } from './index.css';
+import { cardListHome, cardListMypage, infoBox } from './index.css';
 
 interface MyBasketCardListProps {
   type: 'home' | 'mypage';
@@ -11,8 +12,16 @@ interface MyBasketCardListProps {
 const MyBasketCardList = ({ type }: MyBasketCardListProps) => {
   const { data: myBaskets } = useGetMyBaskets();
 
+  const alilmedProducts = myBaskets?.filter(product => product.isAlilm);
+
   return (
     <>
+      {alilmedProducts?.length && (
+        <div className={infoBox}>
+          <BellRing stroke={'#707070'} width={13} />
+          재입고 알림을 보낸 상품에 알림 표시를 해두었어요.
+        </div>
+      )}
       {type === 'home' && (
         <div className={cardListHome}>
           {myBaskets?.map(myBasket => (

--- a/src/components/product/my-basket-card/index.css.ts
+++ b/src/components/product/my-basket-card/index.css.ts
@@ -49,16 +49,3 @@ export const price = style({
   fontWeight: '700',
   color: '#333',
 });
-
-export const deleteBtn = style({
-  all: 'unset',
-  lineHeight: '1.432rem',
-  fontSize: '1.2rem',
-  textAlign: 'center',
-  padding: '0.4rem',
-  marginTop: '0.6rem',
-  color: '#9A9A9A',
-  border: '0.1rem solid #EEEEEE',
-  borderRadius: '0.4rem',
-  cursor: 'pointer',
-});

--- a/src/components/product/my-basket-card/index.css.ts
+++ b/src/components/product/my-basket-card/index.css.ts
@@ -1,18 +1,12 @@
 import { style } from '@vanilla-extract/css';
 
 export const myBasketCard = style({
+  position: 'relative',
   minWidth: '100%',
   width: '100%',
   display: 'flex',
   justifyContent: 'flex-start',
   gap: '3.25%',
-});
-
-export const thumbnailImage = style({
-  maxWidth: '38%',
-  maxHeight: '21.8rem',
-  aspectRatio: '1/1',
-  borderRadius: '1.2rem',
 });
 
 export const productInfo = style({
@@ -24,6 +18,12 @@ export const name = style({
   fontWeight: '700',
   marginBottom: '6px',
   cursor: 'pointer',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  lineHeight: '1.2',
 });
 
 export const options = style({

--- a/src/components/product/my-basket-card/index.tsx
+++ b/src/components/product/my-basket-card/index.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import { useRouter } from 'next/navigation';
-import { useDeleteBasket } from '@/hooks/mutations/use-delete-basket';
-import { useModalStore } from '@/store/use-modal-store';
 import { type MyBasket } from '@/types/basket';
 
 import { BasketBadge } from '../basket-badge';
+import DeleteProductBtn from '../delete-product';
 import ProductThumbnailImage from '../product-thumbnail';
 import WaitingCounts from '../waiting-counts';
 import * as styles from './index.css';
@@ -27,20 +26,6 @@ const MyBasketCard = ({
 }: MyBasketProps) => {
   const description = `${brand}${firstOption ? ` / ${firstOption}` : ''}${secondOption ? ` / ${secondOption}` : ''}${thirdOption ? ` / ${thirdOption}` : ''}`;
 
-  const { mutate: deleteBasket } = useDeleteBasket();
-
-  const onOpen = useModalStore(state => state.onOpen);
-
-  const handleDeleteBtn = () => {
-    onOpen({
-      modalType: 'confirm',
-      title: '상품을 삭제하시겠습니까?',
-      description: name,
-      onClick: () => deleteBasket(id),
-      mainBtnText: '삭제',
-    });
-  };
-
   const router = useRouter();
 
   const openProductDetail = () => {
@@ -57,9 +42,7 @@ const MyBasketCard = ({
         </p>
         <p className={styles.options}>{description}</p>
         <WaitingCounts counts={waitingCount} />
-        <button className={styles.deleteBtn} onClick={handleDeleteBtn}>
-          삭제하기
-        </button>
+        <DeleteProductBtn id={id} name={name} />
       </div>
     </div>
   );

--- a/src/components/product/my-basket-card/index.tsx
+++ b/src/components/product/my-basket-card/index.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useDeleteBasket } from '@/hooks/mutations/use-delete-basket';
 import { useModalStore } from '@/store/use-modal-store';
 import { type MyBasket } from '@/types/basket';
 
 import { BasketBadge } from '../basket-badge';
+import ProductThumbnailImage from '../product-thumbnail';
 import WaitingCounts from '../waiting-counts';
 import * as styles from './index.css';
 
@@ -23,6 +23,7 @@ const MyBasketCard = ({
   secondOption,
   thirdOption,
   waitingCount,
+  isAlilm,
 }: MyBasketProps) => {
   const description = `${brand}${firstOption ? ` / ${firstOption}` : ''}${secondOption ? ` / ${secondOption}` : ''}${thirdOption ? ` / ${thirdOption}` : ''}`;
 
@@ -48,15 +49,7 @@ const MyBasketCard = ({
 
   return (
     <div className={styles.myBasketCard}>
-      <Image
-        src={imageUrl}
-        className={styles.thumbnailImage}
-        alt="Basket Thumbnail"
-        width={200}
-        height={200}
-        style={{ width: '100%', height: 'auto', objectFit: 'cover', cursor: 'pointer' }}
-        onClick={openProductDetail}
-      />
+      <ProductThumbnailImage imageUrl={imageUrl} isAlilm={isAlilm} card={'full'} />
       <div className={styles.productInfo}>
         <BasketBadge>{category}</BasketBadge>
         <p className={styles.name} onClick={openProductDetail}>

--- a/src/components/product/product-card/basket-card-skeleton.tsx
+++ b/src/components/product/product-card/basket-card-skeleton.tsx
@@ -3,7 +3,7 @@ import * as styles from './index.css';
 export default function BasketCardSkeleton() {
   return (
     <div className={styles.basketCard}>
-      <div className={styles.imageWrapper}>
+      <div>
         <div className={styles.skeletonThumbnailImage} />
       </div>
       <div>

--- a/src/components/product/product-card/index.css.ts
+++ b/src/components/product/product-card/index.css.ts
@@ -11,17 +11,15 @@ export const basketCard = style({
   height: '100%',
 });
 
-export const imageWrapper = style({});
-
 export const thumbnailImage = style({
   width: '100%',
   minHeight: '21.8rem',
   height: '21.8rem',
   maxHeight: '21.8rem',
+  borderRadius: '1.2rem',
 
   // height: 'clamp(21.8rem, 21.8rem, 21.8rem)',
-  objectFit: 'contain',
-  borderRadius: '0.4rem',
+  objectFit: 'cover',
 });
 
 export const name = style({
@@ -146,3 +144,14 @@ export const skeletonButton = style([
     borderRadius: '0.4rem',
   },
 ]);
+export const imageWrapper = style({
+  position: 'relative',
+});
+
+export const icon = style({
+  position: 'absolute',
+  top: '4%',
+  right: '5%',
+  zIndex: '2',
+  width: '2rem',
+});

--- a/src/components/product/product-card/index.css.ts
+++ b/src/components/product/product-card/index.css.ts
@@ -11,17 +11,6 @@ export const basketCard = style({
   height: '100%',
 });
 
-export const thumbnailImage = style({
-  width: '100%',
-  minHeight: '21.8rem',
-  height: '21.8rem',
-  maxHeight: '21.8rem',
-  borderRadius: '1.2rem',
-
-  // height: 'clamp(21.8rem, 21.8rem, 21.8rem)',
-  objectFit: 'cover',
-});
-
 export const name = style({
   fontSize: '1.4rem',
   fontWeight: '700',
@@ -144,14 +133,3 @@ export const skeletonButton = style([
     borderRadius: '0.4rem',
   },
 ]);
-export const imageWrapper = style({
-  position: 'relative',
-});
-
-export const icon = style({
-  position: 'absolute',
-  top: '4%',
-  right: '5%',
-  zIndex: '2',
-  width: '2rem',
-});

--- a/src/components/product/product-card/index.css.ts
+++ b/src/components/product/product-card/index.css.ts
@@ -11,6 +11,11 @@ export const basketCard = style({
   height: '100%',
 });
 
+export const productInfo = style({
+  width: '100%',
+  cursor: 'pointer',
+});
+
 export const name = style({
   fontSize: '1.4rem',
   fontWeight: '700',

--- a/src/components/product/product-card/index.tsx
+++ b/src/components/product/product-card/index.tsx
@@ -5,6 +5,7 @@ import { BasketBadge } from '@/components/product/basket-badge';
 import { useCopyBaskets } from '@/hooks/mutations/use-copy-baskets';
 import { type Product } from '@/types/basket';
 
+import DeleteProductBtn from '../delete-product';
 import ProductThumbnailImage from '../product-thumbnail';
 import WaitingCounts from '../waiting-counts';
 import BasketCardSkeleton from './basket-card-skeleton';
@@ -62,19 +63,19 @@ const ProductCard = ({
         />
       </div>
       <div>
-        <div onClick={handleProductClick} style={{ cursor: 'pointer', width: '100%' }}>
+        <div onClick={handleProductClick} className={styles.productInfo}>
           <BasketBadge>{category}</BasketBadge>
           <p className={styles.name}>{name}</p>
           <p className={styles.options}>{description}</p>
         </div>
+        <WaitingCounts counts={waitingCount} />
         {tab === 'home' ? (
-          <>
-            <WaitingCounts counts={waitingCount} />
-            <button onClick={handleWaitTogetherButtonClick} className={styles.waitTogetherButton}>
-              함께 기다리기
-            </button>
-          </>
-        ) : null}
+          <button onClick={handleWaitTogetherButtonClick} className={styles.waitTogetherButton}>
+            함께 기다리기
+          </button>
+        ) : (
+          <DeleteProductBtn id={id} name={name} />
+        )}
       </div>
     </div>
   );

--- a/src/components/product/product-card/index.tsx
+++ b/src/components/product/product-card/index.tsx
@@ -1,12 +1,11 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { BasketBadge } from '@/components/product/basket-badge';
 import { useCopyBaskets } from '@/hooks/mutations/use-copy-baskets';
 import { type Product } from '@/types/basket';
-import { BellRing } from 'lucide-react';
 
+import ProductThumbnailImage from '../product-thumbnail';
 import WaitingCounts from '../waiting-counts';
 import BasketCardSkeleton from './basket-card-skeleton';
 import * as styles from './index.css';
@@ -54,18 +53,13 @@ const ProductCard = ({
   return (
     <div className={styles.basketCard}>
       <div onClick={handleProductClick} style={{ cursor: 'pointer', width: '100%' }}>
-        <div className={styles.imageWrapper}>
-          <Image
-            src={tab === 'home' ? thumbnailUrl : imageUrl}
-            className={styles.thumbnailImage}
-            alt="Basket Thumbnail"
-            layout="responsive"
-            width={0}
-            height={0}
-            sizes="100vw"
-          />
-          {isAlilm && <BellRing stroke="#555BF1" className={styles.icon} />}
-        </div>
+        <ProductThumbnailImage
+          imageUrl={imageUrl}
+          thumbnailUrl={thumbnailUrl}
+          tab={tab}
+          isAlilm={isAlilm}
+          card={'thin'}
+        />
       </div>
       <div>
         <div onClick={handleProductClick} style={{ cursor: 'pointer', width: '100%' }}>

--- a/src/components/product/product-card/index.tsx
+++ b/src/components/product/product-card/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { BasketBadge } from '@/components/product/basket-badge';
 import { useCopyBaskets } from '@/hooks/mutations/use-copy-baskets';
 import { type Product } from '@/types/basket';
+import { BellRing } from 'lucide-react';
 
 import WaitingCounts from '../waiting-counts';
 import BasketCardSkeleton from './basket-card-skeleton';
@@ -13,6 +14,7 @@ import * as styles from './index.css';
 type BasketProps = Product & {
   isLoading?: boolean;
   productId?: number;
+  isAlilm?: string;
 };
 
 const ProductCard = ({
@@ -29,6 +31,7 @@ const ProductCard = ({
   waitingCount,
   tab,
   isLoading,
+  isAlilm,
 }: BasketProps) => {
   const { mutate: copyBasketsMutate } = useCopyBaskets();
 
@@ -51,7 +54,7 @@ const ProductCard = ({
   return (
     <div className={styles.basketCard}>
       <div onClick={handleProductClick} style={{ cursor: 'pointer', width: '100%' }}>
-        <div>
+        <div className={styles.imageWrapper}>
           <Image
             src={tab === 'home' ? thumbnailUrl : imageUrl}
             className={styles.thumbnailImage}
@@ -61,6 +64,7 @@ const ProductCard = ({
             height={0}
             sizes="100vw"
           />
+          {isAlilm && <BellRing stroke="#555BF1" className={styles.icon} />}
         </div>
       </div>
       <div>

--- a/src/components/product/product-thumbnail/index.css.ts
+++ b/src/components/product/product-thumbnail/index.css.ts
@@ -1,0 +1,48 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const imageWrapper = recipe({
+  base: {
+    position: 'relative',
+  },
+  variants: {
+    card: {
+      thin: { width: '100%' },
+      full: {
+        width: '38%',
+      },
+    },
+  },
+  defaultVariants: {
+    card: 'thin',
+  },
+});
+
+export const icon = style({
+  position: 'absolute',
+  top: '4%',
+  right: '5%',
+  zIndex: '2',
+  width: '2rem',
+});
+
+export const thumbnailImage = recipe({
+  base: {
+    borderRadius: '1.2rem',
+    objectFit: 'cover',
+  },
+  variants: {
+    card: {
+      thin: {
+        width: '100%',
+        minHeight: '21.8rem',
+      },
+      full: {
+        aspectRatio: '1/1.2',
+      },
+    },
+  },
+  defaultVariants: {
+    card: 'thin',
+  },
+});

--- a/src/components/product/product-thumbnail/index.tsx
+++ b/src/components/product/product-thumbnail/index.tsx
@@ -1,0 +1,42 @@
+import Image from 'next/image';
+import { type MyBasket, type Product } from '@/types/basket';
+import { BellRing } from 'lucide-react';
+
+import * as styles from './index.css';
+
+export interface ProductThumbnailProps {
+  tab?: 'home' | 'my-basket';
+  card: 'thin' | 'full';
+  thumbnailUrl?: Product['thumbnailUrl'];
+  imageUrl?: Product['imageUrl'];
+  isAlilm?: MyBasket['isAlilm'];
+}
+
+const ProductThumbnailImage = ({
+  tab,
+  card,
+  thumbnailUrl,
+  imageUrl,
+  isAlilm,
+}: ProductThumbnailProps) => {
+  const validURL = tab === 'home' ? thumbnailUrl : imageUrl;
+
+  return (
+    <div className={styles.imageWrapper({ card })}>
+      {validURL && (
+        <Image
+          src={validURL}
+          className={styles.thumbnailImage({ card })}
+          alt="Basket Thumbnail"
+          layout="responsive"
+          width={800}
+          height={800}
+        />
+      )}
+
+      {isAlilm && <BellRing stroke="#555BF1" className={styles.icon} />}
+    </div>
+  );
+};
+
+export default ProductThumbnailImage;

--- a/src/components/product/related-products-list/index.css.ts
+++ b/src/components/product/related-products-list/index.css.ts
@@ -9,4 +9,5 @@ export const cardList = style({
 
 export const cardWrapper = style({
   width: '20rem',
+  margin: '0 0.6rem',
 });

--- a/src/components/product/related-products-list/index.tsx
+++ b/src/components/product/related-products-list/index.tsx
@@ -20,15 +20,14 @@ const RelatedProductList = ({ productId }: RelatedProductListProps) => {
   return (
     <div className={styles.cardList}>
       <Swiper
-        spaceBetween={20}
         slidesPerView={3}
         mousewheel={true}
         modules={[Pagination, Mousewheel]}
         style={{ paddingLeft: '2rem' }}
       >
         {relatedProducts?.relatedProductList.map(product => (
-          <SwiperSlide key={product.id}>
-            <div key={product.id} className={styles.cardWrapper}>
+          <SwiperSlide key={product.id} className={styles.cardWrapper}>
+            <div key={product.id}>
               <ProductCard {...product} />
             </div>
           </SwiperSlide>

--- a/src/types/basket.ts
+++ b/src/types/basket.ts
@@ -32,4 +32,5 @@ export interface MyBasket {
   thirdOption?: string;
   isHidden: boolean;
   waitingCount: number;
+  isAlilm: string;
 }


### PR DESCRIPTION
close #119 

## 작업 내용

- 홈 > 나의알림 탭, 마아페이지 나의 알림 페이지에서 **알림 받은 상품 섬네일 이미지에 알림 아이콘이 표시**되도록 구현했습니다.
  - 이미지에 따라 아이콘 가시성이 떨어지는 문제를 논의 중이신 걸로 파악했습니다. 해당 부분은 추후 디자인 수정까지 이루어지면 반영하겠습니다. 
- 상단에 **알림 아이콘에 대한 설명 배너**를 추가했습니다. (알림 받은 상품이 한 개도 없으면 해당 배너는 표시되지 않습니다.)
- 홈 > 나의알림 탭 상품 카드에 `삭제하기` 버튼과 `함께 기다리는 사람 수`를 추가했습니다.
  - 버튼 디자인 소폭 수정된 점 반영했습니다.
- 이외 재입고 알림 상품 등록 완료 토스트 알림 텍스트가 세로 기준 중앙 정렬되도록 스타일을 수정했습니다. 
 
## 스크린샷

![image](https://github.com/user-attachments/assets/e5e49d6b-2aba-4d46-8193-e7d4624202c9)