### PR TITLE
refactor: 카카오 로그인 페이지(외부 페이지) window.location으로 열리도록 수정

### DIFF
--- a/src/components/login/login-modal/index.tsx
+++ b/src/components/login/login-modal/index.tsx
@@ -15,7 +15,7 @@ const LoginModal = () => {
   const pathname = usePathname();
 
   const handleLoginBtn = () => {
-    router.push(`https://alilm.store/oauth2/authorization/kakao`);
+    window.location.href = `https://alilm.store/oauth2/authorization/kakao`;
   };
 
   const handleCloseModalBtn = () => {


### PR DESCRIPTION
## 작업 내용
 - 카카오 로그인 버튼 클릭 > 뒤로가기 클릭 >로그인 버튼 다시 클릭 시 버튼 동작하지 않는 이슈가 있어 수정했습니다.
 - 기존에 카카오 로그인 페이지로 이동하는 과정에서 내부 URL과 클라이언트 라우팅을 처리하도록 설계된 `router.push`를 사용했기 때문에 외부 URL 이동 후 뒤로가기 시 히스토리 스택과 상태가 꼬여 발생한 문제로 파악했습니다.
 -  `router.push` -> `window.location.href` 로 수정해 해결했습니다.
