### PR TITLE
Feat/#125 - 웹푸시 최초 알림 권한 요청 로직 변경

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -7,31 +7,9 @@ firebase.initializeApp({
   appId: '1:815885197726:web:d3170a092c2ad613a0f68f',
 });
 const messaging = firebase.messaging();
-// 푸시 내용 처리해서 알림 표시
-// self.addEventListener('push', function (event) {});
-
-function registerServiceWorker() {
-  if (typeof window !== 'undefined') {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker
-        .register('/firebase-messaging-sw.js')
-        .then(registration => {
-          console.log('Service Worker Registered', registration);
-        })
-        .catch(error => {
-          console.error('Service Worker Registration Failed', error);
-        });
-    } else {
-      console.warn('Service Worker is not supported in this browser.');
-    }
-  }
-}
-
-registerServiceWorker();
 
 self.addEventListener('push', function (event) {
   if (event.data) {
-    // 알림 메세지일 경우엔 event.data.json().notification;
     const data = event.data.json().data;
     const options = {
       body: data.body,
@@ -48,6 +26,7 @@ self.addEventListener('push', function (event) {
     console.info('This push event has no data.');
   }
 });
+
 // 클릭 이벤트 처리 - 알림을 클릭 시 사이트로 이동
 self.addEventListener('notificationclick', function (event) {
   const clickActionUrl = event.notification.data.click_action;
@@ -60,8 +39,11 @@ messaging.onBackgroundMessage(payload => {
 
   const notificationTitle = payload.notification?.title || 'Default Title';
   const notificationOptions = {
-    body: payload.notification?.body || 'Default Body',
-    icon: payload.notification?.icon || '/default-icon.png',
+    body: payload.notification?.body,
+    icon:
+      data.icon ||
+      'https://file.notion.so/f/f/c345e317-1a77-4e86-8b67-b491a5db92b8/732799dc-6ad9-46f8-8864-22308c10cdb8/free-icon-bells-7124213.png?table=block&id=1037b278-57a0-8022-8a73-ea04c03ae27e&spaceId=c345e317-1a77-4e86-8b67-b491a5db92b8&expirationTimestamp=1730354400000&signature=hBdHPuerhscY6rXIkAe40sWyyvEq22eyqZ7AqA2Gt5o&downloadName=free-icon-bells-7124213.png',
+    image: data.image,
     data: payload.data || {},
   };
 

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -56,7 +56,6 @@ export async function POST(request: NextRequest) {
       brand: productData.brand,
       thumbnailUrl: `https://image.msscdn.net${productData.thumbnailImageUrl}`,
       imageUrlList: productImageUrl ? productImageUrl : [],
-      category: productData.category?.categoryDepth1Title,
       firstCategory: productData.category?.categoryDepth1Title,
       secondCategory: productData.category?.categoryDepth2Title,
       price: productData.goodsPrice?.maxPrice,

--- a/src/components/common/alert/index.css.ts
+++ b/src/components/common/alert/index.css.ts
@@ -32,6 +32,7 @@ export const title = style({
   color: tokens.colors.textPrimary,
   marginBottom: '1.4rem',
   lineHeight: '3rem',
+  wordBreak: 'break-word',
 });
 
 export const description = style({
@@ -40,6 +41,7 @@ export const description = style({
   color: tokens.colors.textPrimary,
   marginBottom: '3rem',
   whiteSpace: 'pre-line',
+  wordBreak: 'break-word',
 });
 
 export const btnContainer = style({

--- a/src/components/main/onboarding/index.tsx
+++ b/src/components/main/onboarding/index.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from 'react';
 import Image from 'next/image';
 import Modal from '@/components/common/modal/modal';
+import handleFcmToken from '@/utils/handle-fcm-token';
 import { EffectFade, Navigation, Pagination } from 'swiper/modules';
 import { Swiper, type SwiperClass, SwiperSlide } from 'swiper/react';
 
@@ -36,6 +37,7 @@ const OnboardingModal = ({ onClose }: OnboardingProps) => {
       if (swiperRef.current.isEnd) {
         localStorage.setItem('showOnboarding', 'completed');
         onClose();
+        handleFcmToken();
       } else {
         swiperRef.current.slideNext();
       }


### PR DESCRIPTION
## 작업 내용
- 웹푸시 최초 권한 알림 요청 시점이 기존 로그인 완료 시점에서 유저가 온보딩 모달 '닫기' 버튼을 누르는 시점으로 변경했습니다.
  - iOS 정책에 맞게 PWA에서 특정 트리거를 통해 권한 요청 팝업이 뜨도록 하기 위함 
  - 이외 얼럿창 텍스트 내 띄어쓰기가 포함되어 있지 않은 긴 텍스트의 경우 레이아웃 깨지는 문제를 수정했습니다.
