### PR TITLE
Feat/#125 - fcm 토큰 전송 로직 변경

### DIFF
--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -75,6 +75,9 @@ const ProductDetail = ({ params }: ProductDetailProps) => {
       case 'CM29':
         productUrl = `https://product.29cm.co.kr/catalog/${number}`;
         break;
+      case 'ZIGZAG':
+        productUrl = `https://zigzag.kr/catalog/products/${number}`;
+        break;
       default:
         console.error('지원하지 않는 플랫폼입니다.');
 

--- a/src/components/main/onboarding/index.tsx
+++ b/src/components/main/onboarding/index.tsx
@@ -38,11 +38,15 @@ const OnboardingModal = ({ onClose }: OnboardingProps) => {
     if (swiperRef.current) {
       if (swiperRef.current.isEnd) {
         localStorage.setItem('showOnboarding', 'completed');
-        onClose();
         if (isMessagingSupported) {
-          const { default: handleFcmToken } = await import('@/utils/handle-fcm-token');
-          await handleFcmToken();
+          try {
+            const { default: handleFcmToken } = await import('@/utils/handle-fcm-token');
+            await handleFcmToken();
+          } catch (error) {
+            console.error('FCM 토큰 설정 중 오류 발생:', error);
+          }
         }
+        onClose();
       } else {
         swiperRef.current.slideNext();
       }

--- a/src/utils/handle-fcm-token.ts
+++ b/src/utils/handle-fcm-token.ts
@@ -26,9 +26,6 @@ export const handleFcmToken = async () => {
     }
 
     localStorage.setItem('fcm-token', fcmToken);
-
-    // 토큰 발급 성공 시 서버로 토큰 전송
-    // await postFcmToken(fcmToken);
   } catch (error) {
     console.error('에러 발생:', error);
   }


### PR DESCRIPTION
## 작업 내용

- 로그인 시점에 fcm 토큰 없을 시 재요청
- 온보딩 모달 - fcm 토큰 발행 이후 onClose 되도록 수정
- 판매사이트로 이동 - 지그재그 url 추가

