### PR TITLE
fix: Android 환경 background 모드에서도 앱푸시 받을 수 있도록 수정

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -35,16 +35,13 @@ self.addEventListener('notificationclick', function (event) {
 });
 
 messaging.onBackgroundMessage(payload => {
-  console.log('[firebase-messaging-sw.js] Received background message ', payload);
-
-  const notificationTitle = payload.notification?.title || 'Default Title';
+  const data = payload.data || {};
+  const notificationTitle = payload.notification?.title || data.title || '알림';
   const notificationOptions = {
-    body: payload.notification?.body,
-    icon:
-      data.icon ||
-      'https://file.notion.so/f/f/c345e317-1a77-4e86-8b67-b491a5db92b8/732799dc-6ad9-46f8-8864-22308c10cdb8/free-icon-bells-7124213.png?table=block&id=1037b278-57a0-8022-8a73-ea04c03ae27e&spaceId=c345e317-1a77-4e86-8b67-b491a5db92b8&expirationTimestamp=1730354400000&signature=hBdHPuerhscY6rXIkAe40sWyyvEq22eyqZ7AqA2Gt5o&downloadName=free-icon-bells-7124213.png',
-    image: data.image,
-    data: payload.data || {},
+    body: payload.notification?.body || data.body || '메시지 내용 없음',
+    icon: payload.notification?.icon || data.icon || 'https://example.com/default-icon.png',
+    image: payload.notification?.image || data.image,
+    data: { click_action: data.click_action },
   };
 
   self.registration.showNotification(notificationTitle, notificationOptions);

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -11,6 +11,7 @@ import { useModalStore } from '@/store/use-modal-store';
 import { Navigation, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { type PaginationOptions } from 'swiper/types';
+
 import * as styles from './index.css';
 
 import 'swiper/css';

--- a/src/components/product/product-card/index.tsx
+++ b/src/components/product/product-card/index.tsx
@@ -8,6 +8,7 @@ import { BasketBadge } from '@/components/product/basket-badge';
 import { useCopyBaskets } from '@/hooks/mutations/use-copy-baskets';
 import { type Product } from '@/types/basket';
 import { getMessageSentStatus } from '@/utils/local-storage';
+
 import DeleteProductBtn from '../delete-product';
 import ProductThumbnailImage from '../product-thumbnail';
 import BasketCardSkeleton from './basket-card-skeleton';


### PR DESCRIPTION
## 작업 내용

- 안드로이드 백그라운드 모드에서 앱푸시 알림 받을 수 없는 이슈 해결을 위한 작업을 진행했습니다.
  -  이슈 원인
    - 백그라운드 푸시 설정 시, 안드로이드의 경우 notification 객체를 받는 iOS와 다르게 data 객체로 담아 보내야 합니다.

