### PR TITLE
fix: notification 키 값 제거

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -34,13 +34,16 @@ self.addEventListener('notificationclick', function (event) {
   event.waitUntil(clients.openWindow(clickActionUrl));
 });
 
+// 백그라운드 메시지 처리
 messaging.onBackgroundMessage(payload => {
+  console.log('[firebase-messaging-sw.js] Received background message', payload);
+
   const data = payload.data || {};
-  const notificationTitle = payload.notification?.title || data.title || '알림';
+  const notificationTitle = data.title || '알림';
   const notificationOptions = {
-    body: payload.notification?.body || data.body || '메시지 내용 없음',
-    icon: payload.notification?.icon || data.icon || 'https://example.com/default-icon.png',
-    image: payload.notification?.image || data.image,
+    body: data.body || '메시지 내용 없음',
+    icon: data.icon || 'https://example.com/default-icon.png',
+    image: data.image || '',
     data: { click_action: data.click_action },
   };
 


### PR DESCRIPTION
## 작업 내용

- 서비스 워커 > notification 키 값 제거
  - 이 경우 iOS에서 푸시 알림 받을 수 없게되지만, 안드로이드에서는 수신 가능한지 우선 확인하기
  - 안드로이드 수신 가능하다면 이후 서버의 gateway 코드에서 OS에 따른 분기 처리 필요

