### PR TITLE
fix: 상품 등록 완료 라우팅 경로 수정

### DIFF
--- a/src/hooks/mutations/use-registered-baskets.ts
+++ b/src/hooks/mutations/use-registered-baskets.ts
@@ -36,7 +36,7 @@ export const useRegisteredBaskets = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [PRODUCTS_QUERY_KEY, MY_BASKETS_QUERY_KEY] });
       showToast('재입고 알림 상품이 등록되었습니다.');
-      router.replace('/?tab=myAlilm');
+      router.replace('/my-alilm');
     },
     onError: error => {
       onOpen({ modalType: 'alert', title: error.message });


### PR DESCRIPTION
## 작업 내용

- 상품 등록 완료 라우팅 경로 수정
  - `홈 > 나의알림` 탭이 제거됨에 따라, 상품 등록 완료 시 랜딩되는 페이지를 해당 탭에서 `마이페이지 > 나의알림 `페이지로 변경했습니다.

## 스크린샷

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->
